### PR TITLE
Replace "use_lifecycle" to "lifecycle_enable"

### DIFF
--- a/modules/backup/examples/all_options.tf
+++ b/modules/backup/examples/all_options.tf
@@ -45,7 +45,7 @@ module "backup" {
   completion_window = 600
 
   # Use Lifecycle Cold Storage
-  use_lifecycle = true
+  lifecycle_enable = true
   lifecycle_bu = {
     cold_storage_after = 10
     delete_after       = 100


### PR DESCRIPTION
##### Versions used 
terraform required_version = ">= 0.12"
aws version             = "~> 3.0"

"use_lifecycle" is not a valid argument based on module
"lifecycle_enable" is the proper argument

##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section

##### Summary of change(s):
Replace "use_lifecycle" to "lifecycle_enable"
##### Reason for Change(s):
Bug/Typo:
```hcl
Error: Unsupported argument

  on main.tf line 294, in module "backup":
 294:   use_lifecycle = false

An argument named "use_lifecycle" is not expected here.
```

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

##### If input variables or output variables have changed or has been added, have you updated the README?
Not needed as the details in README is correct.
##### Do examples need to be updated based on changes?

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
